### PR TITLE
Allow placing objects under beams

### DIFF
--- a/1.6/Defs/ThingDefs_Buildings/Buildings_SupportBeams.xml
+++ b/1.6/Defs/ThingDefs_Buildings/Buildings_SupportBeams.xml
@@ -59,7 +59,7 @@
         <texPath>Things/Building/Linked/Wall_Blueprint_Atlas</texPath>
       </blueprintGraphicData>
       <canPlaceOverWall>true</canPlaceOverWall>
-      <isEdifice>true</isEdifice>
+      <isEdifice>false</isEdifice>
       <canPlaceOverImpassablePlant>true</canPlaceOverImpassablePlant>
     </building>
     <damageMultipliers>


### PR DESCRIPTION
## Summary
- make SupportBeam non-edifice so other objects can share the same cell

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f197d1f048332b2587c15325927ac